### PR TITLE
Check for paru AUR helper and prefer it for installation

### DIFF
--- a/etc/skel/.bin/main/linux-lts kernel/1-install-lts-kernel-v3.sh
+++ b/etc/skel/.bin/main/linux-lts kernel/1-install-lts-kernel-v3.sh
@@ -32,7 +32,12 @@ if pacman -Qi $package &> /dev/null; then
 else
 
 	#checking which helper is installed
-	if pacman -Qi yay &> /dev/null; then
+	if pacman -Qi paru &> /dev/null; then
+
+		echo "Installing with paru"
+		paru -S --noconfirm $package
+
+	elif pacman -Qi yay &> /dev/null; then
 
 		echo "Installing with yay"
 		yay -S --noconfirm $package
@@ -40,7 +45,7 @@ else
 	elif pacman -Qi trizen &> /dev/null; then
 
 		echo "Installing with trizen"
-		trizen -S --noconfirm --noedit  $package
+		trizen -S --noconfirm --noedit $package
 
 	fi
 


### PR DESCRIPTION
Paru should be the preferred option for installing packages with AUR helper. Some systems may not even have yay or trizen installed anymore, but paru is encouraged in the current ArcoLinux versions, and therefore should be used primarily in ArcoLinux build scripts.